### PR TITLE
Escape Keys during JSON encoding

### DIFF
--- a/src/_webjsonEncode.m
+++ b/src/_webjsonEncode.m
@@ -65,7 +65,7 @@ SERARY(VVROOT) ; Serialize into a JSON array
 SERNAME(VVSUB) ; Serialize the object name into JSON string
  I $E(VVSUB)="""" S VVSUB=$E(VVSUB,2,$L(VVSUB)) ; quote indicates numeric label
  I ($L(VVSUB)+$L(@VVJSON@(VVLINE)))>VVMAX S VVLINE=VVLINE+1,@VVJSON@(VVLINE)=""
- S @VVJSON@(VVLINE)=@VVJSON@(VVLINE)_""""_VVSUB_""""_":"
+ S @VVJSON@(VVLINE)=@VVJSON@(VVLINE)_""""_$$ESC(VVSUB)_""""_":"
  Q
 SERVAL(VVROOT,VVSUB) ; Serialize X into appropriate JSON representation
  N VVX,VVI,VVDONE

--- a/src/_webjsonEncodeTest.m
+++ b/src/_webjsonEncodeTest.m
@@ -178,6 +178,12 @@ EXAMPLE ;; @TEST encode samples that are on JSON.ORG
  D ASSERT(TARGET,$E(JSON(1)_JSON(2)_JSON(3),1,215))
  D ASSERT(95,$L(JSON(1)))
  Q
+KEYESC ;; @TEST keys should be escaped
+ N Y,JSON,TARGET
+ S Y("names","x(834038,""237745"":""240474"")")="AREG"
+ D ENCODE^%webjson("Y","JSON")
+ D ASSERT(JSON(1),"{""names"":{""x(834038,\""237745\"":\""240474\"")"":""AREG""}}")
+ Q
 BUILDY(LABEL) ; build Y array based on LABEL
  ; expects Y from EXAMPLE
  N I,X


### PR DESCRIPTION
Keys can contain data that should be escaped. Also add test containing
data that should be escaped.