### PR TITLE
Add support for escaped keys in JSON decoder

### DIFF
--- a/src/_webjsonDecodeTest.m
+++ b/src/_webjsonDecodeTest.m
@@ -267,6 +267,16 @@ ESCQ ;; @TEST escaped quote across lines
  D ASSERT(0,$D(ERR))
  D ASSERT(42,$L(Y("bjw")))
  Q
+KEYQUOTE ;; @TEST keys with quotes
+ N ENCODE,JSON,Y,ERR
+ S JSON="{""a(1,3:\""\"")"":""AREG""}"
+ D DECODE^%webjson("JSON","Y","ERR")
+ D ASSERT(0,$D(ERR))
+ D ASSERT("AREG",$G(Y("a(1,3:"""")")))
+ K ERR
+ D ENCODE^%webjson("Y","ENCODE","ERR")
+ D ASSERT(ENCODE(1),JSON)
+ Q
 BUILD(TAG,JSON) ; Build array of strings in JSON for TAG
  N X,I,LINE
  S LINE=1,JSON(LINE)=""


### PR DESCRIPTION
The JSON decoder assumed that there would never be escaped characters
in the key (before the ":" character) when in reality this can happen.
Add support to unescape the characters and support setting the M array
key with the unescaped string.

Add unit test to test that the changed code works and will continue
to work.