### PR TITLE
Names split across multiple lines parsing broke.

### DIFF
--- a/src/_webjsonDecode.m
+++ b/src/_webjsonDecode.m
@@ -1,4 +1,4 @@
-%webjsonDecode ;SLC/KCM -- Decode JSON;Feb 07, 2019@10:54
+%webjsonDecode ;SLC/KCM -- Decode JSON;2019-03-01  10:44 AM
  ;
 DECODE(VVJSON,VVROOT,VVERR) ; Set JSON object into closed array ref VVROOT
  ;
@@ -160,7 +160,7 @@ NAMPARS() ; Return parsed name, advancing index past the close quote
  . I $E(@VVJSON@(VVLINE),VVEND-2)="\" S VVIDX=VVEND Q
  . I VVEND S VVNAME=VVNAME_$E(@VVJSON@(VVLINE),VVSTART,VVEND-2),VVIDX=VVEND,VVDONE=1
  . I 'VVEND S VVNAME=VVNAME_$E(@VVJSON@(VVLINE),VVSTART,$L(@VVJSON@(VVLINE)))
- . I 'VVEND!(VVEND>$L(@VVJSON@(VVLINE))) S VVLINE=VVLINE+1,VVIDX=1 I '$D(@VVJSON@(VVLINE)) D ERRX("ORN")
+ . I 'VVEND!(VVEND>$L(@VVJSON@(VVLINE))) S VVLINE=VVLINE+1,(VVIDX,VVSTART)=1 I '$D(@VVJSON@(VVLINE)) D ERRX("ORN")
  ; prepend quote if label collates as numeric -- assumes no quotes in label
  I VVNAME']]$C(1) S VVNAME=""""""_VVNAME
  Q VVNAME

--- a/src/_webjsonDecodeTest.m
+++ b/src/_webjsonDecodeTest.m
@@ -1,4 +1,4 @@
-%webjsonDecodeTest ;SLC/KCM -- Unit tests for JSON decoding;Feb 07, 2019@10:55
+%webjsonDecodeTest ;SLC/KCM -- Unit tests for JSON decoding;2019-03-01  10:44 AM
  ;
  d EN^%ut($t(+0),3)
  quit
@@ -77,6 +77,20 @@ SPLITC ;; @TEST multiple line JSON input with lines split inside boolean value
  D ASSERT("SQA,ONE",$G(Y("assignToName")))
  D ASSERT("urn:va:user:2C0A:1134",$G(Y("assignToCode")))
  Q
+SPLITD ;; @TEST multiple line JSON input with key split
+ n json,y,err
+ s json(1)="{ ""boo"": ""foo"", ""code"" : ""22-2""}"
+ d decode^%webjson("json","y","err")
+ D ASSERT(0,$D(err))
+ D ASSERT(y("code"),"22-2")
+ n json,y,err
+ s json(1)="{ ""boo"": ""foo"", ""c"
+ s json(2)="ode"": ""22-2""}"
+ d decode^%webjson("json","y","err")
+ D ASSERT(0,$D(err))
+ D ASSERT(y("code"),"22-2")
+ quit
+ ;
 LONG ;; @TEST long document that must be saved across extension nodes
  N JSON,Y,ERR,I,LINE,CCNT1,CCNT2
  S JSON(1)="{""title"":""long document"",""size"":""rather large"",""document"":"""


### PR DESCRIPTION
It broke with commit fcefa1b5e5793653d45436885117165bef3d555e.

We added the VVSTART variable, but forgot to re-initailize it with VVIDX
when a name is split over mulitple lines. Now it's fixed, and we now
have a Unit Test that tests for it.