### PR TITLE
Fix json parsing

### DIFF
--- a/src/_webjson.m
+++ b/src/_webjson.m
@@ -1,4 +1,4 @@
-%webjson ;SLC/KCM -- Decode/Encode JSON;Feb 07, 2019@10:51
+%webjson ;SLC/KCM -- Decode/Encode JSON;2019-07-16  2:17 PM
  ;
  ; Note:  Since the routines use closed array references, VVROOT and VVERR
  ;        are used to reduce risk of naming conflicts on the closed array.
@@ -63,6 +63,7 @@ ERRX(ID,VAL) ; Set the appropriate error message
  I ID="OR#" S ERRMSG="Overrun while scanning number." G XERRX
  I ID="ORB" S ERRMSG="Overrun while scanning boolean." G XERRX
  I ID="ESC" S ERRMSG="Escaped character not recognized"_VAL G XERRX
+ I ID="TRL" S ERRMSG="Trailing characters in JSON object: "_VAL G XERRX
  ;
  ; Encode Error Messages
  ;

--- a/src/_webjsonDecode.m
+++ b/src/_webjsonDecode.m
@@ -1,4 +1,4 @@
-%webjsonDecode ;SLC/KCM -- Decode JSON;2019-03-01  10:44 AM
+%webjsonDecode ;SLC/KCM -- Decode JSON;2019-07-16  2:17 PM
  ;
 DECODE(VVJSON,VVROOT,VVERR) ; Set JSON object into closed array ref VVROOT
  ;
@@ -29,10 +29,16 @@ DIRECT ; TAG for use by DECODE^%webjson
  F  S VVTYPE=$$NXTKN() Q:VVTYPE=""  D  I VVERRORS Q
  . I VVTYPE="{" S VVSTACK=VVSTACK+1,VVSTACK(VVSTACK)="",VVPROP=1 D:VVSTACK>64 ERRX("STL{") Q
  . I VVTYPE="}" D  QUIT
- . . I VVSTACK(VVSTACK)?1n.n,VVSTACK(VVSTACK) D ERRX("OBM") ; Numeric and true only
- . . S VVSTACK=VVSTACK-1 D:VVSTACK<0 ERRX("SUF}")
+ . . I VVSTACK'>0 D ERRX("SUF}") Q  ; Extra Brace. Nothing to pop.
+ . . I VVSTACK(VVSTACK)?1n.n,VVSTACK(VVSTACK) D ERRX("OBM") Q  ; Numeric and true only
+ . . S VVSTACK=VVSTACK-1
  . I VVTYPE="[" S VVSTACK=VVSTACK+1,VVSTACK(VVSTACK)=1 D:VVSTACK>64 ERRX("STL[") Q
  . I VVTYPE="]" D:'VVSTACK(VVSTACK) ERRX("ARM") S VVSTACK=VVSTACK-1 D:VVSTACK<0 ERRX("SUF]") Q
+ . ;
+ . ; At this point, we should be in a brace or a bracket (indicated by VVSTACK>0)
+ . ; If not we have an error condition
+ . I VVSTACK'>0 D ERRX("TRL",VVTYPE) Q
+ . ;
  . I VVTYPE="," D  Q
  . . I +VVSTACK(VVSTACK)=VVSTACK(VVSTACK),VVSTACK(VVSTACK) S VVSTACK(VVSTACK)=VVSTACK(VVSTACK)+1  ; VEN/SMH - next in array
  . . E  S VVPROP=1                                   ; or next property name

--- a/src/_webjsonDecodeTest.m
+++ b/src/_webjsonDecodeTest.m
@@ -1,4 +1,4 @@
-%webjsonDecodeTest ;SLC/KCM -- Unit tests for JSON decoding;2019-03-01  10:44 AM
+%webjsonDecodeTest ;SLC/KCM -- Unit tests for JSON decoding;2019-07-16  2:17 PM
  ;
  d EN^%ut($t(+0),3)
  quit
@@ -168,6 +168,16 @@ BADQUOTE ;; @TEST poorly formed JSON (missing close quote on LABEL)
 BADSLASH ;; @TEST poorly formed JSON (non-escaped backslash)
  N JSON,Y,ERR
  D BUILD("BADSLASH",.JSON) D DECODE^%webjson("JSON","Y","ERR")
+ D ASSERT(1,$D(ERR)>0)
+ Q
+BADBRACE ;; @TEST poorly formed JSON (Extra Brace)
+ N JSON,Y,ERR
+ D BUILD("BADBRACE",.JSON) D DECODE^%webjson("JSON","Y","ERR")
+ D ASSERT(1,$D(ERR)>0)
+ Q
+BADCOMMA ;; @TEST poorly formed JSON (Extra Comma)
+ N JSON,Y,ERR
+ D BUILD("BADCOMMA",.JSON) D DECODE^%webjson("JSON","Y","ERR")
  D ASSERT(1,$D(ERR)>0)
  Q
 PSNUM ;; @TEST subjects that look like a numbers shouldn't be encoded as numbers

--- a/src/_webjsonTestData1.m
+++ b/src/_webjsonTestData1.m
@@ -1,4 +1,4 @@
-VPRJUJ01 ;SLC/KCM -- Sample data for JSON decoding;Feb 07, 2019@10:56
+VPRJUJ01 ;SLC/KCM -- Sample data for JSON decoding;2019-07-16  2:18 PM
  ;
  ;
  ; Portions of this code are public domain, but it was extensively modified
@@ -56,6 +56,14 @@ BADSLASH ;;
  ;;and other escaped characters such as \n  and a few tabs \t\t\t\t and
  ;; a piece of \"quoted text\"", "nextLineQuote":"here is another string
  ;;"}
+ ;;#####
+ ;
+BADBRACE ;;
+ ;;{"test":[4,3,2]}}
+ ;;#####
+ ;
+BADCOMMA ;;
+ ;;{"test":[4,3,2]},
  ;;#####
  ;
 PSNUM ;; Psudo-neumeric tests


### PR DESCRIPTION
Github Issue #32.

Decoder crashes on:

{"test":[4,3,2]}}

{"test":[4,3,2]},

due to assuming that we will always get valid JSON. This commit fixes
these class of bugs of trailing characters and incorrect braces. I am
sure there will be more of these bugs in the future.