### PR TITLE
[#15] Move URL matcher list to separate routine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ set(source_files
   src/_webreq.m
   src/_webrsp.m
   src/_webutils.m
+  src/_weburl.m
 )
 
 # Add commands to compile .m files

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -220,7 +220,7 @@ MATCHR(ROUTINE,ARGS) ; Match against this routine
  S:$E(PATH)="/" PATH=$E(PATH,2,$L(PATH))
  N SEQ,PATMETHOD
  N DONE S DONE=0
- F SEQ=1:1 S PATTERN=$P($T(URLMAP+SEQ),";;",2,99) Q:PATTERN="zzzzz"  D  Q:DONE
+ F SEQ=1:1 S PATTERN=$P($T(URLMAP+SEQ^%weburl),";;",2,99) Q:PATTERN="zzzzz"  D  Q:DONE
  . K ARGS
  . S ROUTINE=$P(PATTERN," ",3),PATMETHOD=$P(PATTERN," "),PATTERN=$P(PATTERN," ",2),FAIL=0
  . I $L(PATTERN,"/")'=$L(PATH,"/") S ROUTINE="" Q  ; must have same number segments
@@ -395,11 +395,6 @@ XML(RESULT,ARGS) ; text XML
  S ^TMP($J,6)="<body>Don't forget me this weekend!</body>"
  S ^TMP($J,7)="</note>"
  QUIT
- ;
-URLMAP ; map URLs to entry points (HTTP methods handled within entry point)
- ;;GET ping PING^%webrsp
- ;;GET xml XML^%webrsp
- ;;zzzzz
  ;
 AUTHEN(HTTPAUTH) ; Authenticate User against VISTA from HTTP Authorization Header
  ;

--- a/src/_weburl.m
+++ b/src/_weburl.m
@@ -1,0 +1,23 @@
+%weburl ;YottaDB/CJE -- URL Matching routine;2019-08-26
+ ;
+ ; This routine is used to map URLs to entry points under
+ ; the URLMAP entry point.
+ ;
+URLMAP ;
+ ;;GET ping PING^%webrsp
+ ;;GET xml XML^%webrsp
+ ;;zzzzz
+ ;
+ ; Copyright 2019 Christopher Edwards
+ ;
+ ;Licensed under the Apache License, Version 2.0 (the "License");
+ ;you may not use this file except in compliance with the License.
+ ;You may obtain a copy of the License at
+ ;
+ ;    http://www.apache.org/licenses/LICENSE-2.0
+ ;
+ ;Unless required by applicable law or agreed to in writing, software
+ ;distributed under the License is distributed on an "AS IS" BASIS,
+ ;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ;See the License for the specific language governing permissions and
+ ;limitations under the License.


### PR DESCRIPTION
The routine based URL matcher list is now a separate routine (vs
being a sub routine in ^%webrsp) as that allows for easier overrides
by other applications that include the M Web Server in their code.

Fixes #15 