### PR TITLE
CORS configuration support

### DIFF
--- a/src/_webreq.m
+++ b/src/_webreq.m
@@ -202,13 +202,11 @@ WAIT ; wait for request on this connection
  . I HTTPLOG>2 D LOGBODY
  ;
  N CORS
- I $G(NOGBL) D
- . S CORS("enabled")=$G(CORSENAB)
- . S CORS("credentials")=$G(CORSCRED)
- . S CORS("method")=$G(CORSMETH)
- . S CORS("header")=$G(CORSHDRS)
- . S CORS("origin")=$G(CORSORG)
- E  I $D(^%webhttp(0,"cors")) M CORS=^%webhttp(0,"cors")
+ S CORS("enabled")=$G(CORSENAB)
+ S CORS("credentials")=$G(CORSCRED)
+ S CORS("method")=$G(CORSMETH)
+ S CORS("header")=$G(CORSHDRS)
+ S CORS("origin")=$G(CORSORG)
  ;
  ; -- build response (map path to routine & call, otherwise 404)
  S $ETRAP="G ETCODE^%webreq"

--- a/src/_webreq.m
+++ b/src/_webreq.m
@@ -7,13 +7,13 @@ go ; start up REST listener with defaults
  D job(PORT)
  QUIT
  ;
-job(PORT,TLSCONFIG,NOGBL,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED) ; Convenience entry point
+job(PORT,TLSCONFIG,NOGBL,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED,CORSMXAG) ; Convenience entry point
  I $L($G(USERPASS))&($G(USERPASS)'[":") W "USERPASS argument is invalid, must be in username:password format!" QUIT
- I $P($SY,",")=47 J start^%webreq(PORT,,$G(TLSCONFIG),$G(NOGBL),,$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED)):(IN="/dev/null":OUT="/dev/null":ERR="webreq.mje"):5  ; no in and out files please.
- E  J start^%webreq(PORT,"",$G(TLSCONFIG),$G(NOGBL),"",$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED)) ; Cache can't accept empty arguments. Change to empty strings.
+ I $P($SY,",")=47 J start^%webreq(PORT,,$G(TLSCONFIG),$G(NOGBL),,$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED),$G(CORSMXAG)):(IN="/dev/null":OUT="/dev/null":ERR="webreq.mje"):5  ; no in and out files please.
+ E  J start^%webreq(PORT,"",$G(TLSCONFIG),$G(NOGBL),"",$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED),$G(CORSMXAG)) ; Cache can't accept empty arguments. Change to empty strings.
  QUIT
  ;
-start(TCPPORT,DEBUG,TLSCONFIG,NOGBL,TRACE,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED) ; set up listening for connections
+start(TCPPORT,DEBUG,TLSCONFIG,NOGBL,TRACE,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED,CORSMXAG) ; set up listening for connections
  ; I hope TCPPORT needs no explanations.
  ;
  ; DEBUG is so that we run our server in the foreground.
@@ -62,7 +62,7 @@ LOOP ; wait for connection, spawn process to handle it. GOTO favorite.
  I %WOS="CACHE" D  G LOOP
  . R *X:10
  . E  QUIT  ; Loop back again when listening and nobody on the line
- . J CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED)):(:4:TCPIO:TCPIO):10 ; Send off the device to another job for input and output.
+ . J CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED),$G(CORSMXAG)):(:4:TCPIO:TCPIO):10 ; Send off the device to another job for input and output.
  . i $ZA\8196#2=1 W *-2  ; job failed to clear bit
  ; ---- END CACHE CODE ----
  ;
@@ -86,7 +86,7 @@ LOOP ; wait for connection, spawn process to handle it. GOTO favorite.
  . . U TCPIO:(detach=CHILDSOCK)
  . . N Q S Q=""""
  . . N ARG S ARG=Q_"SOCKET:"_CHILDSOCK_Q
- . . N J S J="CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED)):(input="_ARG_":output="_ARG_")"
+ . . N J S J="CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(CORSENAB),$G(CORSHDRS),$G(CORSMETH),$G(CORSORG),$G(CORSCRED),$G(CORSMXAG)):(input="_ARG_":output="_ARG_")"
  . . J @J
  . ;
  . ; GT.M before 6.1:
@@ -138,7 +138,7 @@ GTMLNX  ;From Linux xinetd script; $P is the main stream
  ; HTTPLOG indicates the logging level for this process
  ; HTTPERR non-zero if there is an error state
  ;
-CHILD(TLSCONFIG,NOGBL,TRACE,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED) ; handle HTTP requests on this connection
+CHILD(TLSCONFIG,NOGBL,TRACE,USERPASS,CORSENAB,CORSHDRS,CORSMETH,CORSORG,CORSCRED,CORSMXAG) ; handle HTTP requests on this connection
 CHILDDEBUG ; [Internal] Debugging entry point
  S %WTCP=$GET(TCPIO,$PRINCIPAL) ; TCP Device
  S %WOS=$S($P($SY,",")=47:"GT.M",$P($SY,",")=50:"MV1",1:"CACHE") ; Get Mumps Virtual Machine
@@ -207,6 +207,7 @@ WAIT ; wait for request on this connection
  S CORS("method")=$G(CORSMETH)
  S CORS("header")=$G(CORSHDRS)
  S CORS("origin")=$G(CORSORG)
+ S CORS("maxAge")=$G(CORSMXAG)
  ;
  ; -- build response (map path to routine & call, otherwise 404)
  S $ETRAP="G ETCODE^%webreq"

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -272,13 +272,20 @@ SENDATA ; write out the data as an HTTP response
  . D W("Content-Type: "_HTTPRSP("mime")_$C(13,10)) K HTTPRSP("mime") ; Mime-type
  E  D W("Content-Type: application/json; charset=utf-8"_$C(13,10))
  ;
- ; Add CORS Header
+ ; Access-Control-Allow-Origin :- specifies either a single origin, which tells browsers to allow that origin to access the resource;
+ ;        or else — for requests without credentials — the "*" wildcard, to tell browsers to allow any origin to access the resource
+ ; Access-Control-Max-Age :- indicates how long the results of a preflight request can be cached
+ ; Access-Control-Allow-Credentials :- indicates whether or not the response to the request can be exposed when the credentials flag is true
+ ; Access-Control-Allow-Methods :- specifies the method or methods allowed when accessing the resource
+ ; Access-Control-Allow-Headers :- is used in response to a preflight request to indicate which HTTP headers can be used when making the actual request.
+ ;
+ ; Add CORS headers
  I $G(CORS("enabled"))="Y" D
  . I $G(HTTPREQ("method"))="OPTIONS" D
  . . D W("Access-Control-Allow-Credentials: "_CORS("credentials")_$C(13,10))
  . . D W("Access-Control-Allow-Methods: "_CORS("method")_$C(13,10))
  . . D W("Access-Control-Allow-Headers: "_CORS("header")_$C(13,10))
- . . D W("Access-Control-Max-Age: 86400"_$C(13,10))
+ . . D W("Access-Control-Max-Age: "_CORS("maxAge")_$C(13,10))
  . D W("Access-Control-Allow-Origin: "_CORS("origin")_$C(13,10))
  ;
  I $P($SY,",")=47,$G(HTTPREQ("header","accept-encoding"))["gzip" GOTO GZIP  ; If on GT.M, and we can zip, let's do that!

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -273,17 +273,13 @@ SENDATA ; write out the data as an HTTP response
  E  D W("Content-Type: application/json; charset=utf-8"_$C(13,10))
  ;
  ; Add CORS Header
- I $G(NOGBL) D
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Methods: OPTIONS, POST"_$C(13,10))
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Headers: Content-Type"_$C(13,10))
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
- . D W("Access-Control-Allow-Origin: *"_$C(13,10))
- E  I $G(^%webhttp(0,"cors","enabled"))="Y"  D
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Credentials: "_^%webhttp(0,"cors","credentials")_$C(13,10))
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Methods: "_^%webhttp(0,"cors","method")_$C(13,10))
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Headers: "_^%webhttp(0,"cors","header")_$C(13,10))
- . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
- . D W("Access-Control-Allow-Origin: "_^%webhttp(0,"cors","origin")_$C(13,10))
+ I $G(CORS("enabled"))="Y" D
+ . I $G(HTTPREQ("method"))="OPTIONS" D
+ . . D W("Access-Control-Allow-Credentials: "_CORS("credentials")_$C(13,10))
+ . . D W("Access-Control-Allow-Methods: "_CORS("method")_$C(13,10))
+ . . D W("Access-Control-Allow-Headers: "_CORS("header")_$C(13,10))
+ . . D W("Access-Control-Max-Age: 86400"_$C(13,10))
+ . D W("Access-Control-Allow-Origin: "_CORS("origin")_$C(13,10))
  ;
  I $P($SY,",")=47,$G(HTTPREQ("header","accept-encoding"))["gzip" GOTO GZIP  ; If on GT.M, and we can zip, let's do that!
  ;

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -273,10 +273,17 @@ SENDATA ; write out the data as an HTTP response
  E  D W("Content-Type: application/json; charset=utf-8"_$C(13,10))
  ;
  ; Add CORS Header
- I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Methods: OPTIONS, POST"_$C(13,10))
- I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Headers: Content-Type"_$C(13,10))
- I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
- D W("Access-Control-Allow-Origin: *"_$C(13,10))
+ I $G(NOGBL) D
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Methods: OPTIONS, POST"_$C(13,10))
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Headers: Content-Type"_$C(13,10))
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
+ . D W("Access-Control-Allow-Origin: *"_$C(13,10))
+ E  I $G(^%webhttp(0,"cors","enabled"))="Y"  D
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Credentials: "_^%webhttp(0,"cors","credentials")_$C(13,10))
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Methods: "_^%webhttp(0,"cors","method")_$C(13,10))
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Allow-Headers: "_^%webhttp(0,"cors","header")_$C(13,10))
+ . I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
+ . D W("Access-Control-Allow-Origin: "_^%webhttp(0,"cors","origin")_$C(13,10))
  ;
  I $P($SY,",")=47,$G(HTTPREQ("header","accept-encoding"))["gzip" GOTO GZIP  ; If on GT.M, and we can zip, let's do that!
  ;

--- a/src/_webtest.m
+++ b/src/_webtest.m
@@ -15,9 +15,8 @@ STARTUP ; [Adjust the acvc and dfn to suit your environment]
  VIEW "TRACE":1:"^%wtrace"
  kill ^%webhttp("log")
  kill ^%webhttp(0,"logging")
- kill ^%webhttp(0,"cors")
  do resetURLs
- job start^%webreq(55728,,,,1):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
+ job start^%webreq(55728,,,,1,,"Y","Content-Type","OPTIONS, POST","*","true"):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
  set myJob=$zjob
  hang .1
  quit
@@ -303,7 +302,6 @@ tINIT ; @TEST Test Fileman INIT code
  ;
 CORS ; @TEST Make sure CORS headers are returned
  k ^%webhttp("log",+$H)
- do setupCORS
  n httpStatus,return,headers,headerarray
  d &libcurl.curl(.httpStatus,.return,"OPTIONS","http://127.0.0.1:55728/r/kbbotest.m",,,,.headers)
  ;
@@ -318,25 +316,6 @@ CORS ; @TEST Make sure CORS headers are returned
  d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Headers")),"Content-Type")
  d CHKEQ^%ut($g(headerarray("Access-Control-Max-Age")),"86400")
  d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Origin")),"*")
- quit
- ;
-NOCORS ; @TEST Make sure CORS headers are not returned
- k ^%webhttp("log",+$H)
- kill ^%webhttp(0,"cors")
- n httpStatus,return,headers,headerarray
- d &libcurl.curl(.httpStatus,.return,"OPTIONS","http://127.0.0.1:55728/r/kbbotest.m",,,,.headers)
- ;
- ; Split the headers apart using carriage return line feed delimiter
- f i=1:1:$L(headers,$C(13,10)) D
- . ; Change to name based subscripts by using ": " delimiter
- . s:($p($p(headers,$C(13,10),i),": ",1)'="")&($p($p(headers,$C(13,10),i),": ",2)'="") headerarray($p($p(headers,$C(13,10),i),": ",1))=$p($p(headers,$C(13,10),i),": ",2)
- ;
- ; Now make sure all required bits are correct
- d CHKEQ^%ut(httpStatus,200)
- d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Methods")),"")
- d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Headers")),"")
- d CHKEQ^%ut($g(headerarray("Access-Control-Max-Age")),"")
- d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Origin")),"")
  quit
  ;
 USERPASS ; @TEST Test that passing a username/password works
@@ -473,14 +452,6 @@ resetURLs ; Reset all the URLs; Called upon start-up
  do addService^%webutils("POST","rpc/{rpc}","RPC^%webapi",1)
  n params s params(1)="U^rpc",params(2)="F^start",params(3)="F^direction",params(4)="B"
  n ien s ien=$$addService^%webutils("POST","rpc2/{rpc}","rpc2^%webapi",1,"","",.params)
- quit
- ;
-setupCORS ; Set CORS Configuration
- S ^%webhttp(0,"cors","enabled")="Y"
- S ^%webhttp(0,"cors","credentials")="true"
- S ^%webhttp(0,"cors","method")="OPTIONS, POST"
- S ^%webhttp(0,"cors","header")="Content-Type"
- S ^%webhttp(0,"cors","origin")="*"
  quit
  ;
 XTROU ;

--- a/src/_webtest.m
+++ b/src/_webtest.m
@@ -16,7 +16,7 @@ STARTUP ; [Adjust the acvc and dfn to suit your environment]
  kill ^%webhttp("log")
  kill ^%webhttp(0,"logging")
  do resetURLs
- job start^%webreq(55728,,,,1,,"Y","Content-Type","OPTIONS, POST","*","true"):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
+ job start^%webreq(55728,,,,1,,"Y","Content-Type","OPTIONS, POST","*","true",86400):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
  set myJob=$zjob
  hang .1
  quit
@@ -358,7 +358,7 @@ NOGBL ; @TEST Test to make sure no globals are used during webserver operations
  n nogblJob
  ;
  ; Now start a webserver with a passed username/password
- j start^%webreq(55731,"",,1,,,"Y","Content-Type","OPTIONS, POST","*","true")
+ j start^%webreq(55731,"",,1,,,"Y","Content-Type","OPTIONS, POST","*","true",86400)
  h .1
  s nogblJob=$zjob
  ;

--- a/src/_webtest.m
+++ b/src/_webtest.m
@@ -15,7 +15,9 @@ STARTUP ; [Adjust the acvc and dfn to suit your environment]
  VIEW "TRACE":1:"^%wtrace"
  kill ^%webhttp("log")
  kill ^%webhttp(0,"logging")
+ kill ^%webhttp(0,"cors")
  do resetURLs
+ do setupCORS
  job start^%webreq(55728,,,,1):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
  set myJob=$zjob
  hang .1
@@ -139,7 +141,7 @@ trpc1 ; @TEST Run a VistA RPC w/o authentication - should fail
  d &libcurl.cleanup
  d CHKEQ^%ut(httpStatus,401)
  quit
- 
+ ;
 trpc2 ; @TEST Run a VistA RPC (requires authentication - ac/vc provided)
  n httpStatus,return
  i $text(^XUS)="" quit  ; VistA not installed
@@ -450,6 +452,14 @@ resetURLs ; Reset all the URLs; Called upon start-up
  do addService^%webutils("POST","rpc/{rpc}","RPC^%webapi",1)
  n params s params(1)="U^rpc",params(2)="F^start",params(3)="F^direction",params(4)="B"
  n ien s ien=$$addService^%webutils("POST","rpc2/{rpc}","rpc2^%webapi",1,"","",.params)
+ quit
+ ;
+setupCORS ; Set CORS Configuration
+ S ^%webhttp(0,"cors","enabled")="Y"
+ S ^%webhttp(0,"cors","credentials")="Y"
+ S ^%webhttp(0,"cors","method")="OPTIONS, POST"
+ S ^%webhttp(0,"cors","header")="Content-Type"
+ S ^%webhttp(0,"cors","origin")="*"
  quit
  ;
 XTROU ;

--- a/src/_webtest.m
+++ b/src/_webtest.m
@@ -17,7 +17,6 @@ STARTUP ; [Adjust the acvc and dfn to suit your environment]
  kill ^%webhttp(0,"logging")
  kill ^%webhttp(0,"cors")
  do resetURLs
- do setupCORS
  job start^%webreq(55728,,,,1):(IN="/dev/null":OUT="/dev/null":ERR="/dev/null"):5
  set myJob=$zjob
  hang .1
@@ -304,6 +303,7 @@ tINIT ; @TEST Test Fileman INIT code
  ;
 CORS ; @TEST Make sure CORS headers are returned
  k ^%webhttp("log",+$H)
+ do setupCORS
  n httpStatus,return,headers,headerarray
  d &libcurl.curl(.httpStatus,.return,"OPTIONS","http://127.0.0.1:55728/r/kbbotest.m",,,,.headers)
  ;
@@ -318,6 +318,25 @@ CORS ; @TEST Make sure CORS headers are returned
  d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Headers")),"Content-Type")
  d CHKEQ^%ut($g(headerarray("Access-Control-Max-Age")),"86400")
  d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Origin")),"*")
+ quit
+ ;
+NOCORS ; @TEST Make sure CORS headers are not returned
+ k ^%webhttp("log",+$H)
+ kill ^%webhttp(0,"cors")
+ n httpStatus,return,headers,headerarray
+ d &libcurl.curl(.httpStatus,.return,"OPTIONS","http://127.0.0.1:55728/r/kbbotest.m",,,,.headers)
+ ;
+ ; Split the headers apart using carriage return line feed delimiter
+ f i=1:1:$L(headers,$C(13,10)) D
+ . ; Change to name based subscripts by using ": " delimiter
+ . s:($p($p(headers,$C(13,10),i),": ",1)'="")&($p($p(headers,$C(13,10),i),": ",2)'="") headerarray($p($p(headers,$C(13,10),i),": ",1))=$p($p(headers,$C(13,10),i),": ",2)
+ ;
+ ; Now make sure all required bits are correct
+ d CHKEQ^%ut(httpStatus,200)
+ d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Methods")),"")
+ d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Headers")),"")
+ d CHKEQ^%ut($g(headerarray("Access-Control-Max-Age")),"")
+ d CHKEQ^%ut($g(headerarray("Access-Control-Allow-Origin")),"")
  quit
  ;
 USERPASS ; @TEST Test that passing a username/password works
@@ -360,7 +379,7 @@ NOGBL ; @TEST Test to make sure no globals are used during webserver operations
  n nogblJob
  ;
  ; Now start a webserver with a passed username/password
- j start^%webreq(55731,"",,1)
+ j start^%webreq(55731,"",,1,,,"Y","Content-Type","OPTIONS, POST","*","true")
  h .1
  s nogblJob=$zjob
  ;
@@ -448,6 +467,8 @@ resetURLs ; Reset all the URLs; Called upon start-up
  do addService^%webutils("GET","r/{routine?.1""%25"".32AN}","R^%webapi")
  do addService^%webutils("PUT","r/{routine?.1""%25"".32AN}","PR^%webapi",1,"XUPROGMODE")
  do addService^%webutils("GET","error","ERR^%webapi")
+ do addService^%webutils("GET","ping","PING^%webrsp")
+ do addService^%webutils("GET","xml","XML^%webrsp")
  do addService^%webutils("GET","bigoutput","bigoutput^%webapi")
  do addService^%webutils("POST","rpc/{rpc}","RPC^%webapi",1)
  n params s params(1)="U^rpc",params(2)="F^start",params(3)="F^direction",params(4)="B"
@@ -456,7 +477,7 @@ resetURLs ; Reset all the URLs; Called upon start-up
  ;
 setupCORS ; Set CORS Configuration
  S ^%webhttp(0,"cors","enabled")="Y"
- S ^%webhttp(0,"cors","credentials")="Y"
+ S ^%webhttp(0,"cors","credentials")="true"
  S ^%webhttp(0,"cors","method")="OPTIONS, POST"
  S ^%webhttp(0,"cors","header")="Content-Type"
  S ^%webhttp(0,"cors","origin")="*"

--- a/src/webinit.m
+++ b/src/webinit.m
@@ -16,7 +16,7 @@ post ; [Public] Run this entry point if you don't want to download the code.
  ;
  ; Load the URLs
  D LOADHAND
- ; 
+ ;
  ; Set the home directory for the server
  N % S %=$$HOMEDIR
  I '% QUIT
@@ -24,6 +24,12 @@ post ; [Public] Run this entry point if you don't want to download the code.
  ; Set start port
  N PORT S PORT=$$PORT()
  I PORT=0 QUIT
+ ;
+ K ^%webhttp(0)
+ S ^%webhttp(0,"port")=PORT
+ ;
+ ; Set CORS config
+ D CORS()
  ;
  ; Start Server
  D job^%webreq(PORT)
@@ -314,7 +320,7 @@ TESTD47(DIR) ; $$ ; Can I write to this directory in GT.M?
  QUIT 1
  ;
 TESTDET ; Open File Error handler
- S $EC="" 
+ S $EC=""
  QUIT 0
  ;
  ; Load URL handlers
@@ -400,6 +406,44 @@ PORTOKER ; Error handler for open port
  I $ES QUIT
  S $EC=""
  QUIT 0
+ ;
+CORS() ; $$; set CORS configuration
+ S ^%webhttp(0,"cors","enabled")="N"
+ N TMP
+ R !,"Do you want to enable CORS: Y/N// ",TMP:30
+ I (TMP="Y")!(TMP="N") S ^%webhttp(0,"cors","enabled")=TMP
+ I ^%webhttp(0,"cors","enabled")="N" Q
+ N TMPORG
+ACAO ; Set Allowed Origins
+ N TMP
+ R !,"Access Control Allowed Origin: // ",TMP:30
+ I TMP'="" S TMPORG=$G(TMPORG)_TMP_","
+ N TMP
+ R !,"Add more origins: Y/N// ",TMP:30
+ I TMP="Y" GOTO ACAO
+ I '$G(TMPORG) S ^%webhttp(0,"cors","origin")=$E(TMPORG,0,$L(TMPORG)-1) ; Remove trailing comma
+ N TMP
+ R !,"Access Control Allow Credentials: true/false// ",TMP:30
+ I (TMP="true")!(TMP="false") S ^%webhttp(0,"cors","credentials")=TMP
+ N TMPMTH
+ACAM ; Set Allowed Methods
+ N TMP
+ R !,"Access Control Allowed Method: POST/PUT/GET/DELETE/OPTIONS// ",TMP:30
+ I (TMP="POST")!(TMP="PUT")!(TMP="GET")!(TMP="DELETE")!(TMP="OPTIONS") S TMPMTH=$G(TMPMTH)_TMP_","
+ N TMP
+ R !,"Add more methods: Y/N// ",TMP:30
+ I TMP="Y" GOTO ACAM
+ I '$G(TMPMTH) S ^%webhttp(0,"cors","method")=$E(TMPMTH,0,$L(TMPMTH)-1)
+ N TMPHDR
+ACAH ; Set Allowed Headers
+ N TMP
+ R !,"Access Control Allowed Header: // ",TMP:30
+ I TMP'="" S TMPHDR=$G(TMPHDR)_TMP_","
+ N TMP
+ R !,"Add more headers: Y/N// ",TMP:30
+ I TMP="Y" GOTO ACAH
+ I '$G(TMPHDR) S ^%webhttp(0,"cors","header")=$E(TMPHDR,0,$L(TMPHDR)-1)
+ Q
  ;
 uninstallMWS ; Remove MWS completely
  if $data(^DD) do

--- a/src/webinit.m
+++ b/src/webinit.m
@@ -33,7 +33,7 @@ post ; [Public] Run this entry point if you don't want to download the code.
  D CORS(.CORS)
  ;
  ; Start Server
- D job^%webreq(PORT,,,,CORS("enabled"),CORS("header"),CORS("method"),CORS("origin"),CORS("credentials"))
+ D job^%webreq(PORT,,,,CORS("enabled"),CORS("header"),CORS("method"),CORS("origin"),CORS("credentials"),CORS("maxAge"))
  ;
  W !!,"Mumps Web Services is now listening to port "_PORT,!
  N SERVER S SERVER="http://localhost:"_PORT_"/"
@@ -415,7 +415,7 @@ CORS(CORS) ; $$; set CORS configuration
  I (TMP="Y")!(TMP="N") S CORS("enabled")=TMP
  I CORS("enabled")="N" Q
  N TMPORG
-ACAO ; Set Allowed Origins
+ACAO ; Set Allowed Origins, Allowed Credentials flag and Max Age value
  N TMP
  R !,"Access Control Allowed Origin: // ",TMP:30
  I TMP'="" S TMPORG=$G(TMPORG)_TMP_","
@@ -426,6 +426,10 @@ ACAO ; Set Allowed Origins
  N TMP
  R !,"Access Control Allow Credentials: true/false// ",TMP:30
  I (TMP="true")!(TMP="false") S CORS("credentials")=TMP
+ N TMP
+ S CORS("maxAge")=86400
+ R !,"Access Control Max Age: (Time in Seconds)// ",TMP:30
+ I (TMP?.N)&TMP>0 S CORS("maxAge")=TMP
  N TMPMTH
 ACAM ; Set Allowed Methods
  N TMP

--- a/src/webinit.m
+++ b/src/webinit.m
@@ -29,10 +29,11 @@ post ; [Public] Run this entry point if you don't want to download the code.
  S ^%webhttp(0,"port")=PORT
  ;
  ; Set CORS config
- D CORS()
+ N CORS
+ D CORS(.CORS)
  ;
  ; Start Server
- D job^%webreq(PORT)
+ D job^%webreq(PORT,,,,CORS("enabled"),CORS("header"),CORS("method"),CORS("origin"),CORS("credentials"))
  ;
  W !!,"Mumps Web Services is now listening to port "_PORT,!
  N SERVER S SERVER="http://localhost:"_PORT_"/"
@@ -407,12 +408,12 @@ PORTOKER ; Error handler for open port
  S $EC=""
  QUIT 0
  ;
-CORS() ; $$; set CORS configuration
- S ^%webhttp(0,"cors","enabled")="N"
+CORS(CORS) ; $$; set CORS configuration
+ S CORS("enabled")="N"
  N TMP
  R !,"Do you want to enable CORS: Y/N// ",TMP:30
- I (TMP="Y")!(TMP="N") S ^%webhttp(0,"cors","enabled")=TMP
- I ^%webhttp(0,"cors","enabled")="N" Q
+ I (TMP="Y")!(TMP="N") S CORS("enabled")=TMP
+ I CORS("enabled")="N" Q
  N TMPORG
 ACAO ; Set Allowed Origins
  N TMP
@@ -421,10 +422,10 @@ ACAO ; Set Allowed Origins
  N TMP
  R !,"Add more origins: Y/N// ",TMP:30
  I TMP="Y" GOTO ACAO
- I '$G(TMPORG) S ^%webhttp(0,"cors","origin")=$E(TMPORG,0,$L(TMPORG)-1) ; Remove trailing comma
+ I '$G(TMPORG) S CORS("origin")=$E(TMPORG,0,$L(TMPORG)-1) ; Remove trailing comma
  N TMP
  R !,"Access Control Allow Credentials: true/false// ",TMP:30
- I (TMP="true")!(TMP="false") S ^%webhttp(0,"cors","credentials")=TMP
+ I (TMP="true")!(TMP="false") S CORS("credentials")=TMP
  N TMPMTH
 ACAM ; Set Allowed Methods
  N TMP
@@ -433,7 +434,7 @@ ACAM ; Set Allowed Methods
  N TMP
  R !,"Add more methods: Y/N// ",TMP:30
  I TMP="Y" GOTO ACAM
- I '$G(TMPMTH) S ^%webhttp(0,"cors","method")=$E(TMPMTH,0,$L(TMPMTH)-1)
+ I '$G(TMPMTH) S CORS("method")=$E(TMPMTH,0,$L(TMPMTH)-1)
  N TMPHDR
 ACAH ; Set Allowed Headers
  N TMP
@@ -442,7 +443,7 @@ ACAH ; Set Allowed Headers
  N TMP
  R !,"Add more headers: Y/N// ",TMP:30
  I TMP="Y" GOTO ACAH
- I '$G(TMPHDR) S ^%webhttp(0,"cors","header")=$E(TMPHDR,0,$L(TMPHDR)-1)
+ I '$G(TMPHDR) S CORS("header")=$E(TMPHDR,0,$L(TMPHDR)-1)
  Q
  ;
 uninstallMWS ; Remove MWS completely


### PR DESCRIPTION
Set server port value in ^%webhttp
Add support for CORS configuration (Refer - https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#The_HTTP_response_headers)
Set cors configuration in ^%webhttp
Updated unit test as well