### PR TITLE
Gzip flag

### DIFF
--- a/src/_webreq.m
+++ b/src/_webreq.m
@@ -7,13 +7,13 @@ go ; start up REST listener with defaults
  D job(PORT)
  QUIT
  ;
-job(PORT,TLSCONFIG,NOGBL,USERPASS) ; Convenience entry point
+job(PORT,TLSCONFIG,NOGBL,USERPASS,NOGZIP) ; Convenience entry point
  I $L($G(USERPASS))&($G(USERPASS)'[":") W "USERPASS argument is invalid, must be in username:password format!" QUIT
- I $P($SY,",")=47 J start^%webreq(PORT,,$G(TLSCONFIG),$G(NOGBL),,$G(USERPASS)):(IN="/dev/null":OUT="/dev/null":ERR="webreq.mje"):5  ; no in and out files please.
- E  J start^%webreq(PORT,"",$G(TLSCONFIG),$G(NOGBL),"",$G(USERPASS)) ; Cache can't accept empty arguments. Change to empty strings.
+ I $P($SY,",")=47 J start^%webreq(PORT,,$G(TLSCONFIG),$G(NOGBL),,$G(USERPASS),$G(NOGZIP)):(IN="/dev/null":OUT="/dev/null":ERR="webreq.mje"):5  ; no in and out files please.
+ E  J start^%webreq(PORT,"",$G(TLSCONFIG),$G(NOGBL),"",$G(USERPASS),$G(NOGZIP)) ; Cache can't accept empty arguments. Change to empty strings.
  QUIT
  ;
-start(TCPPORT,DEBUG,TLSCONFIG,NOGBL,TRACE,USERPASS) ; set up listening for connections
+start(TCPPORT,DEBUG,TLSCONFIG,NOGBL,TRACE,USERPASS,NOGZIP) ; set up listening for connections
  ; I hope TCPPORT needs no explanations.
  ;
  ; DEBUG is so that we run our server in the foreground.
@@ -62,7 +62,7 @@ LOOP ; wait for connection, spawn process to handle it. GOTO favorite.
  I %WOS="CACHE" D  G LOOP
  . R *X:10
  . E  QUIT  ; Loop back again when listening and nobody on the line
- . J CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS)):(:4:TCPIO:TCPIO):10 ; Send off the device to another job for input and output.
+ . J CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(NOGZIP)):(:4:TCPIO:TCPIO):10 ; Send off the device to another job for input and output.
  . i $ZA\8196#2=1 W *-2  ; job failed to clear bit
  ; ---- END CACHE CODE ----
  ;
@@ -86,7 +86,7 @@ LOOP ; wait for connection, spawn process to handle it. GOTO favorite.
  . . U TCPIO:(detach=CHILDSOCK)
  . . N Q S Q=""""
  . . N ARG S ARG=Q_"SOCKET:"_CHILDSOCK_Q
- . . N J S J="CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS)):(input="_ARG_":output="_ARG_")"
+ . . N J S J="CHILD($G(TLSCONFIG),$G(NOGBL),$G(TRACE),$G(USERPASS),$G(NOGZIP)):(input="_ARG_":output="_ARG_")"
  . . J @J
  . ;
  . ; GT.M before 6.1:
@@ -138,7 +138,7 @@ GTMLNX  ;From Linux xinetd script; $P is the main stream
  ; HTTPLOG indicates the logging level for this process
  ; HTTPERR non-zero if there is an error state
  ;
-CHILD(TLSCONFIG,NOGBL,TRACE,USERPASS) ; handle HTTP requests on this connection
+CHILD(TLSCONFIG,NOGBL,TRACE,USERPASS,NOGZIP) ; handle HTTP requests on this connection
 CHILDDEBUG ; [Internal] Debugging entry point
  S %WTCP=$GET(TCPIO,$PRINCIPAL) ; TCP Device
  S %WOS=$S($P($SY,",")=47:"GT.M",$P($SY,",")=50:"MV1",1:"CACHE") ; Get Mumps Virtual Machine

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -278,7 +278,7 @@ SENDATA ; write out the data as an HTTP response
  I $G(HTTPREQ("method"))="OPTIONS" D W("Access-Control-Max-Age: 86400"_$C(13,10))
  D W("Access-Control-Allow-Origin: *"_$C(13,10))
  ;
- I $P($SY,",")=47,$G(HTTPREQ("header","accept-encoding"))["gzip" GOTO GZIP  ; If on GT.M, and we can zip, let's do that!
+ I $P($SY,",")=47,'$G(NOGZIP),$G(HTTPREQ("header","accept-encoding"))["gzip" GOTO GZIP  ; If on GT.M, and we can zip, let's do that!
  ;
  D W("Content-Length: "_SIZE_$C(13,10)_$C(13,10))
  I 'SIZE!(HTTPREQ("method")="HEAD") D FLUSH Q  ; flush buffer and quit if empty

--- a/src/_webtest.m
+++ b/src/_webtest.m
@@ -101,6 +101,32 @@ tgzip ; @TEST Test gzip encoding
  view "badchar"
  quit
  ;
+tnogzipflag ; @TEST Test nogzip flag
+ k ^%webhttp("log",+$H)
+ n gzipflagjob
+ ;
+ ; Now start a webserver with a passed username/password
+ j start^%webreq(55732,"",,,,,1)
+ h .1
+ s gzipflagjob=$zjob
+ ;
+ n httpStatus,return,headers
+ d &libcurl.init
+ d &libcurl.addHeader("Accept-Encoding: gzip") ; This must be sent to properly test as the server is smart and if we don't send that we support gzip it won't gzip
+ n status s status=$&libcurl.do(.httpStatus,.return,"GET","http://127.0.0.1:55732/r/%25webapi",,,1,.headers)
+ do CHKEQ^%ut(httpStatus,200)
+ do CHKTF^%ut(headers'["Content-Encoding: gzip")
+ do CHKTF^%ut(return["webapi ; OSE/SMH - Infrastructure web services hooks")
+ ;
+ ; now stop the webserver again
+ open "p":(command="$gtm_dist/mupip stop "_gzipflagjob)::"pipe"
+ use "p" r x:1
+ close "p"
+ w !,x,!
+ ;
+ kill gzipflagjob
+ quit
+ ;
 tping ; @TEST Ping
  n httpStatus,return
  n status s status=$&libcurl.curl(.httpStatus,.return,"GET","http://127.0.0.1:55728/ping")


### PR DESCRIPTION
Docker containers by default have a limited /dev/shm* size and may
cause unexpected failures if gzip compression is enabled. The default
is to have gzip compression ENABLED.

Add test to make sure even if gzip is supported by the client the
server will ignore it.