### PR TITLE
Updated to install as YottaDB plugin based on AIM installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This is free and unencumbered software released into the public domain.
 #
 # Anyone is free to copy, modify, publish, use, compile, sell, or
@@ -23,4 +24,30 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
-set(CMAKE_MUMPS_COMPILER_WORKS 1 CACHE INTERNAL "")
+cd "$(dirname "$(realpath -e "$0")")"
+if [ -z "$ydb_dist" ] ; then
+    export ydb_dist="$(pkg-config --variable=prefix yottadb)"; ydb_tmp_stat=$?
+    if [ 0 -ne $ydb_tmp_stat ] || [ ! -d $ydb_dist ] ; then
+	echo >&2 YDB installation directory not found. Exiting ; exit $ydb_tmp_stat
+    fi
+fi
+set -e
+# RHEL & derivates use a different cmake command name
+if [ -x "$(command -v cmake3)" ]; then
+  cmakeCommand="cmake3"
+else
+  cmakeCommand="cmake"
+fi											
+rm -rf build && mkdir build && cd build
+echo "Installing M Mode Shared Library"
+$cmakeCommand -DM_NOWARNING=1 -DM_UTF8_MODE=0 ..
+make && make install
+cd ..
+if [ -d "$ydb_dist/utf8" ] ; then
+	echo ""
+	echo "Installing UTF-8 Mode Shared Library"
+	rm -rf build && mkdir build && cd build
+	$cmakeCommand -DM_NOWARNING=1 -DM_UTF8_MODE=1 ..
+	make && make install
+	cd ..
+fi

--- a/ydbcmake/CMakeDetermineMCompiler.cmake
+++ b/ydbcmake/CMakeDetermineMCompiler.cmake
@@ -25,7 +25,7 @@
 
 
 # Sets the following variables:
-#  CMAKE_MUMPS_COMPILER
+#  CMAKE_M_COMPILER
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
@@ -50,7 +50,7 @@ endif()
 find_path(mumps_dir NAMES mumps
 	HINTS $ENV{ydb_dist} $ENV{gtm_dist} ${PC_YOTTADB_INCLUDEDIR} )
 
-if(MUMPS_UTF8_MODE)
+if(M_UTF8_MODE)
   find_program(PKGCONFIG NAMES pkg-config)
   if(PKGCONFIG)
     execute_process(
@@ -91,20 +91,20 @@ if(MUMPS_UTF8_MODE)
       endif()
     endforeach(lc)
     if("${LC_ALL}" STREQUAL "")
-      message("Locale undefined. Expect to see NONUTF8LOCALE during MUMPS routine compilation: ${locale_list}\n")
+      message("Locale undefined. Expect to see NONUTF8LOCALE during M routine compilation: ${locale_list}\n")
     endif()
   else()
     message(FATAL_ERROR "Unable to find 'locale'.  Set LOCALECFG in CMake cache.")
   endif()
-  set(CMAKE_MUMPS_COMPILER ${mumps_dir}/utf8/mumps)
+  set(CMAKE_M_COMPILER ${mumps_dir}/utf8/mumps)
   set(ydb_chset "UTF-8")
 else()
-  set(CMAKE_MUMPS_COMPILER ${mumps_dir}/mumps)
+  set(CMAKE_M_COMPILER ${mumps_dir}/mumps)
 endif()
 
 
-configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeMUMPSCompiler.cmake.in
-  ${CMAKE_PLATFORM_INFO_DIR}/CMakeMUMPSCompiler.cmake
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeMCompiler.cmake.in
+  ${CMAKE_PLATFORM_INFO_DIR}/CMakeMCompiler.cmake
   )
 
-set(CMAKE_MUMPS_COMPILER_ENV_VAR "mumps")
+set(CMAKE_M_COMPILER_ENV_VAR "mumps")

--- a/ydbcmake/CMakeMCompiler.cmake.in
+++ b/ydbcmake/CMakeMCompiler.cmake.in
@@ -23,31 +23,5 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
-set(CMAKE_MUMPS_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> -shared -o <TARGET> <OBJECTS>")
-set(CMAKE_MUMPS_CREATE_SHARED_MODULE "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_C_FLAGS> -o <TARGET> <OBJECTS>")
-set(CMAKE_MUMPS_CREATE_STATIC_LIBRARY "")
-
-# Option to suppress mumps compiler warnings
-option(MUMPS_NOWARNING "Disable warnings and ignore status code from MUMPS compiler")
-option(MUMPS_EMBED_SOURCE "Embed source code in generated shared object" ON)
-option(MUMPS_DYNAMIC_LITERALS "Enable dynamic loading of source code literals" OFF)
-
-set(CMAKE_MUMPS_COMPILE_OBJECT "LC_ALL=\"${LC_ALL}\" ydb_chset=\"${ydb_chset}\" ydb_icu_version=\"${icu_version}\" <CMAKE_MUMPS_COMPILER> -object=<OBJECT>")
-
-if(MUMPS_EMBED_SOURCE)
-  set(CMAKE_MUMPS_COMPILE_OBJECT "${CMAKE_MUMPS_COMPILE_OBJECT} -embed_source")
-endif()
-
-if(MUMPS_DYNAMIC_LITERALS)
-  set(CMAKE_MUMPS_COMPILE_OBJECT "${CMAKE_MUMPS_COMPILE_OBJECT} -dynamic_literals")
-endif()
-
-if(MUMPS_NOWARNING)
-  set(CMAKE_MUMPS_COMPILE_OBJECT "${CMAKE_MUMPS_COMPILE_OBJECT} -nowarning <SOURCE> || true")
-else()
-  set(CMAKE_MUMPS_COMPILE_OBJECT "${CMAKE_MUMPS_COMPILE_OBJECT} <SOURCE>")
-endif()
-
-set(CMAKE_MUMPS_LINK_EXECUTABLE "")
-
-set(CMAKE_MUMPS_OUTPUT_EXTENSION .o)
+set(CMAKE_M_COMPILER "@CMAKE_M_COMPILER@")
+set(CMAKE_M_SOURCE_FILE_EXTENSIONS m)

--- a/ydbcmake/CMakeTestMCompiler.cmake
+++ b/ydbcmake/CMakeTestMCompiler.cmake
@@ -23,5 +23,4 @@
 #
 # For more information, please refer to <http://unlicense.org/>
 
-set(CMAKE_MUMPS_COMPILER "@CMAKE_MUMPS_COMPILER@")
-set(CMAKE_MUMPS_SOURCE_FILE_EXTENSIONS m)
+set(CMAKE_M_COMPILER_WORKS 1 CACHE INTERNAL "")

--- a/ydbcmake/FindYOTTADB.cmake
+++ b/ydbcmake/FindYOTTADB.cmake
@@ -29,7 +29,7 @@
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
-    # See comment in ydbcmake/CMakeDetermineMUMPSCompiler.cmake for why the below two set commands are needed.
+    # See comment in ydbcmake/CMakeDetermineMCompiler.cmake for why the below two set commands are needed.
     set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".so;.a;.dylib")
     pkg_check_modules(PC_YOTTADB QUIET yottadb)
@@ -45,7 +45,11 @@ find_library(YOTTADB_LIBRARY NAMES yottadb gtmshr
   HINTS $ENV{ydb_dist} $ENV{gtm_dist} ${PC_YOTTADB_LIBRARY_DIRS} )
 
 set(YOTTADB_LIBRARIES ${YOTTADB_LIBRARY})
-set(YOTTADB_PLUGIN_DIR "${YOTTADB_INCLUDE_DIRS}/plugin/")
+if(M_UTF8_MODE)
+	set(YOTTADB_PLUGIN_DIR "${YOTTADB_INCLUDE_DIRS}/plugin/o/utf8")
+else()
+	set(YOTTADB_PLUGIN_DIR "${YOTTADB_INCLUDE_DIRS}/plugin/o")
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(YOTTADB  DEFAULT_MSG


### PR DESCRIPTION
- Installs UTF-8 mode shared libary if UTF-8 mode installed
- Copied install.sh and ydbcmake/ from AIM
- Edited install.sh, CMakeLists.txt and ydbcmake/FindYOTTADB.cmake
- Disabled warnings for non-YottaDB/GT.M code