### PR TITLE
[#50] Report errors in NOGBL mode; misc small changes

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -57,7 +57,7 @@ in your shell. If you see anything other than a blank, you are ready to go.
 
 On the linux terminal, Use cURL to download the bootstrap routine.
 
-    curl -L https://github.com/shabiel/M-Web-Server/releases/download/1.1.2/webinit.rsa > /tmp/webinit.rsa
+    curl -L https://github.com/shabiel/M-Web-Server/releases/download/1.1.3/webinit.rsa > /tmp/webinit.rsa
 
 Run GT.M/YottaDB using `$gtm_dist/mumps -dir` or `$ydb_dist/yottadb -dir`.
 
@@ -176,7 +176,7 @@ Then download the bootstrap file as follows:
 
 	C:\Users\VISTAEXPERTISE>cd %temp%
 
-	C:\Users\VISTAE~1\AppData\Local\Temp>curl -k -L -O https://github.com/shabiel/M-Web-Server/releases/download/1.1.2/webinit.rsa
+	C:\Users\VISTAE~1\AppData\Local\Temp>curl -k -L -O https://github.com/shabiel/M-Web-Server/releases/download/1.1.3/webinit.rsa
 
 Open the Cache Terminal from the Cache Cube, or use another method to get in. Read the routine archive in. Cache will complain that it doesn't recoginze GT.M's format. Ignore this error.
 
@@ -265,7 +265,7 @@ Open the Linux Terminal.
 
 Use cURL to download the bootstrap routine.
 
-    curl -L https://github.com/shabiel/M-Web-Server/releases/download/1.1.2/webinit.rsa > /tmp/webinit.rsa
+    curl -L https://github.com/shabiel/M-Web-Server/releases/download/1.1.3/webinit.rsa > /tmp/webinit.rsa
 
 Open the Cache Terminal using `csession CACHE`, and switch to the appropriate
 namespace.

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -12,8 +12,8 @@ us at r/{routine}. From the home page, we know that it calls R^%W0. So what we
 can do is put a break point there, and then launch the web server in debug mode.
 
 ```
-ZB R^%W0
-D START^VPRJREQ(9080,1)
+zbreak R^%webapi
+D start^%webreq(9080,1)
 ```
 
 Now, we need to make a web service call to get a routine. In another terminal

--- a/doc/important-utilities.md
+++ b/doc/important-utilities.md
@@ -21,7 +21,7 @@ Decoding is done using:
 `D DECODE^%webjson(JSON ARRAY INPUT BY NAME, M DEST ARRAY BY NAME, ERROR MESSAGES BY NAME)`
 
 The first two arguments are required; the third argument is optional. If
-not supplied, error messages will be dumped into `^TMP("VPRJERR",$J)`.
+not supplied, error messages will be dumped into `^TMP("%webjsonerr",$J)`.
 
 For novice Mumpsters, an array input by name is something like this:
 

--- a/src/_webapi.m
+++ b/src/_webapi.m
@@ -1,4 +1,4 @@
-%webapi ; OSE/SMH - Infrastructure web services hooks;2019-11-14  11:35 AM
+%webapi ; OSE/SMH - Infrastructure web services hooks;Jun 20, 2022@14:45
  ;
 R(RESULT,ARGS) ; [Public] GET /r/{routine} Mumps Routine
  S RESULT("mime")="text/plain; charset=utf-8"
@@ -209,14 +209,12 @@ F(RESULT,ARGS) ; handles fileman/{file}/{iens}
  QUIT
  ;
 POSTTEST(ARGS,BODY,RESULT) ; POST XML to a WP field in Fileman; handles /xmlpost
- N IEN S IEN=$O(^%W(6.6002,""),-1)+1
- N %WFDA S %WFDA(6.6002,"?+1,",.01)=IEN D UPDATE^DIE("",$NA(%WFDA))
- S RESULT="/fileman/6.6002/"_IEN_"/"_1 ; Stored URL
- N PARSED ; Parsed array which stores each line on a separate node.
- D PARSE10^%webutils(.BODY,.PARSED) ; Parser
- D WP^DIE(6.6002,IEN_",",1,"K",$NA(PARSED)) ; File WP field; lock record in process.
- ; ZSHOW "V":^KBANPARSED
+ N PARAMS ; Parsed array which stores each line on a separate node.
+ D decode^%webjson($NA(BODY),$NA(PARAMS),$NA(%WERR))
+ I $D(%WERR) D SETERROR^%webutils("400","Input parameters not correct") QUIT ""
+ ;
  S RESULT("mime")="text/plain; charset=utf-8" ; Character set of the return URL
+ S RESULT="/fileman/6.6002/"_PARAMS("random")_"/1" ; Stored URL
  Q RESULT
  ;
 RPC(ARGS,BODY,RESULT) ; POST to execute Remote Procedure Calls; handles POST rpc/{rpc}
@@ -355,6 +353,11 @@ FILESYS(RESULT,ARGS) ; Handle filesystem/*
  set MIMELKUP("wav")="audio/wav"
  set MIMELKUP("xls")="application/vnd.ms-excel"
  set MIMELKUP("zip")="application/zip"
+ set MIMELKUP("woff")="font/woff"
+ set MIMELKUP("woff2")="font/woff2"
+ set MIMELKUP("ttf")="font/ttf"
+ set MIMELKUP("eot")="font/eot"
+ set MIMELKUP("otf")="font/otf"
  new EXT set EXT=$PIECE(PATH,".",$LENGTH(PATH,"."))
  if $DATA(MIMELKUP(EXT)) set RESULT("mime")=MIMELKUP(EXT)
  else  set RESULT("mime")=MIMELKUP("txt")
@@ -373,6 +376,7 @@ FILESYSE ; 500
  ;
  ; Copyright 2013-2020 Sam Habiel
  ; Copyright 2018 Kenneth McLoghlen
+ ; Copyright 2022 YottaDB LLC
  ;
  ;Licensed under the Apache License, Version 2.0 (the "License");
  ;you may not use this file except in compliance with the License.

--- a/src/_webhome.m
+++ b/src/_webhome.m
@@ -1,6 +1,7 @@
-%webhome ; VEN/SMH - Home page processor;Feb 07, 2019@10:49
+%webhome ; VEN/SMH - Home page processor;Jun 20, 2022@14:46
  ;;
  ; Copyright 2013-2019 Sam Habiel
+ ; Copyright 2022 YottaDB LLC
  ;
  ;Licensed under the Apache License, Version 2.0 (the "License");
  ;you may not use this file except in compliance with the License.
@@ -20,7 +21,8 @@ en(RESULT) ; PEP
  N ARGS S ARGS("*")="index.html"
  ; Retrieve index.html from filesystem before returning default page
  D FILESYS^%webapi(.RESULT,.ARGS)
- I ('$G(NOGBL)),$D(^TMP("HTTPERR",$J)) K ^TMP("HTTPERR",$J),HTTPERR,RESULT
+ ; If we have an error, it means we don't have an index page; ignore and return handlers page instead
+ I $D(HTTPERR) K HTTPERR,RESULT
  ; If we found an index.html don't return the default
  I $D(RESULT) QUIT
  ; If we are in no global mode quit as well as the below loop won't tell us anything
@@ -29,6 +31,7 @@ en(RESULT) ; PEP
  S RESULT("mime")="text/html; charset=utf-8"
  N I F I=1:1 S RESULT(I)=$P($TEXT(HTML+I),";;",2,99) Q:RESULT(I)=""  D
  . I RESULT(I)["<%TABLEDATA%>" D
+ .. I '$DATA(^%web(17.6001)) SET RESULT(I)="<strong>No web request handlers installed.</strong>"
  .. N IEN S IEN=0 F J=I:.0001 S IEN=$O(^%web(17.6001,IEN)) Q:'IEN  D
  ... S RESULT(J)="<tr>",J=J+.0001
  ... S RESULT(J)="<td>"_^%web(17.6001,IEN,0)_"</td>",J=J+.0001

--- a/src/_webjson.m
+++ b/src/_webjson.m
@@ -5,12 +5,12 @@
  ;
 decode(VVJSON,VVROOT,VVERR) G DIRECT^%webjsonDecode
 DECODE(VVJSON,VVROOT,VVERR)  ; Set JSON object into closed array ref VVROOT
- ; Examples: D DECODE^VPRJSON("MYJSON","LOCALVAR","LOCALERR")
- ;           D DECODE^VPRJSON("^MYJSON(1)","^GLO(99)","^TMP($J)")
+ ; Examples: D decode^%webjson("MYJSON","LOCALVAR","LOCALERR")
+ ;           D decode^%webjson("^MYJSON(1)","^GLO(99)","^TMP($J)")
  ;
  ; VVJSON: string/array containing serialized JSON object
  ; VVROOT: closed array reference for M representation of object
- ;  VVERR: contains error messages, defaults to ^TMP("VPRJERR",$J)
+ ;  VVERR: contains error messages, defaults to ^TMP("%webjsonerr",$J)
  ;
  ;   VVIDX: points to next character in JSON string to process
  ; VVSTACK: manages stack of subscripts
@@ -20,12 +20,12 @@ DECODE(VVJSON,VVROOT,VVERR)  ; Set JSON object into closed array ref VVROOT
  ;
 encode(VVROOT,VVJSON,VVERR) G DIRECT^%webjsonEncode
 ENCODE(VVROOT,VVJSON,VVERR) ; VVROOT (M structure) --> VVJSON (array of strings)
- ; Examples:  D ENCODE^VPRJSON("^GLO(99,2)","^TMP($J)")
- ;            D ENCODE^VPRJSON("LOCALVAR","MYJSON","LOCALERR")
+ ; Examples:  D encode^%webjson("^GLO(99,2)","^TMP($J)")
+ ;            D encode^%webjson("LOCALVAR","MYJSON","LOCALERR")
  ;
  ; VVROOT: closed array reference for M representation of object
  ; VVJSON: destination variable for the string array formatted as JSON
- ;  VVERR: contains error messages, defaults to ^TMP("VPRJERR",$J)
+ ;  VVERR: contains error messages, defaults to ^TMP("%webjsonerr",$J)
  ;
  G DIRECT^%webjsonEncode
  ;

--- a/src/_webjsonDecode.m
+++ b/src/_webjsonDecode.m
@@ -5,8 +5,8 @@ DECODE(VVJSON,VVROOT,VVERR) ; Set JSON object into closed array ref VVROOT
  ;
 DIRECT ; TAG for use by DECODE^%webjson
  ;
- ; Examples: D DECODE^%webjson("MYJSON","LOCALVAR","LOCALERR")
- ;           D DECODE^%webjson("^MYJSON(1)","^GLO(99)","^TMP($J)")
+ ; Examples: D decode^%webjson("MYJSON","LOCALVAR","LOCALERR")
+ ;           D decode^%webjson("^MYJSON(1)","^GLO(99)","^TMP($J)")
  ;
  ; VVJSON: string/array containing serialized JSON object
  ; VVROOT: closed array reference for M representation of object

--- a/src/_webjsonEncode.m
+++ b/src/_webjsonEncode.m
@@ -3,10 +3,10 @@
 encode(VVROOT,VVJSON,VVERR) G DIRECT
 ENCODE(VVROOT,VVJSON,VVERR) ; VVROOT (M structure) --> VVJSON (array of strings)
  ;
-DIRECT ; TAG for use by ENCODE^%webjson
+DIRECT ; TAG for use by encode^%webjson
  ;
- ; Examples:  D ENCODE^%webjson("^GLO(99,2)","^TMP($J)")
- ;            D ENCODE^%webjson("LOCALVAR","MYJSON","LOCALERR")
+ ; Examples:  D encode^%webjson("^GLO(99,2)","^TMP($J)")
+ ;            D encode^%webjson("LOCALVAR","MYJSON","LOCALERR")
  ;
  ; VVROOT: closed array reference for M representation of object
  ; VVJSON: destination variable for the string array formatted as JSON

--- a/src/_webreq.m
+++ b/src/_webreq.m
@@ -1,4 +1,4 @@
-%webreq ;SLC/KCM -- Listen for HTTP requests;2019-11-14  2:05 PM
+%webreq ;SLC/KCM -- Listen for HTTP requests;Jun 20, 2022@14:46
  ;
  ; Listener Process ---------------------------------------
  ;
@@ -167,7 +167,7 @@ TLS ; Turn on TLS?
  ;
 NEXT ; begin next request
  K HTTPREQ,HTTPRSP,HTTPERR
- K:'$G(NOGBL) ^TMP($J),^TMP("HTTPERR",$J) ; TODO: change the namespace for the error global
+ K:'$G(NOGBL) ^TMP($J)
  ;
 WAIT ; wait for request on this connection
  I '$G(NOGBL),$E($G(^%webhttp(0,"listener")),1,4)="stop" C %WTCP Q
@@ -217,7 +217,7 @@ WAIT ; wait for request on this connection
  ;
  ; -- exit on Connection: Close (or if tracing is on so that we can get our trace results)
  I $$LOW^%webutils($G(HTTPREQ("header","connection")))="close"!$G(TRACE) D  HALT
- . K:'$G(NOGBL) ^TMP($J),^TMP("HTTPERR",$J)
+ . K:'$G(NOGBL) ^TMP($J)
  . C %WTCP
  ;
  ; -- otherwise get ready for the next request
@@ -291,9 +291,9 @@ ETCODE ; error trap when calling out to routines
  S ERRARR("place")=$STACK($STACK(-1),"PLACE")
  S ERRARR("mcode")=$STACK($STACK(-1),"MCODE")
  S ERRARR("logID")=HTTPLOG("ID")
- D:'$G(NOGBL) SETERROR^%webutils(501,,.ERRARR) ; sets HTTPERR
+ D SETERROR^%webutils(501,,.ERRARR) ; sets HTTPERR
  D LOGERR
- D:'$G(NOGBL) RSPERROR^%webrsp  ; switch to error response
+ D RSPERROR^%webrsp  ; switch to error response
  D SENDATA^%webrsp
  ; This next line will 'unwind' the stack and got back to listening
  ; for the next HTTP request (goto NEXT).
@@ -301,14 +301,14 @@ ETCODE ; error trap when calling out to routines
  Q
 ETDC ; error trap for client disconnect ; not a true M trap
  D:HTTPLOG LOGDC
- K:'$G(NOGBL) ^TMP($J),^TMP("HTTPERR",$J)
+ K:'$G(NOGBL) ^TMP($J)
  C $P  
  HALT ; Stop process 
  ;
 ETBAIL ; error trap of error traps
  U %WTCP
  W "HTTP/1.1 500 Internal Server Error",$C(13,10),$C(13,10),!
- K:'$G(NOGBL) ^TMP($J),^TMP("HTTPERR",$J)
+ K:'$G(NOGBL) ^TMP($J)
  C %WTCP
  HALT  ; exit because we can't recover
  ;
@@ -395,6 +395,7 @@ stop ; tell the listener to stop running
  ; Portions of this code are public domain, but it was extensively modified
  ; Copyright 2013-2019 Sam Habiel
  ; Copyright 2018-2019 Christopher Edwards
+ ; Copyright 2022 YottaDB LLC
  ;
  ;Licensed under the Apache License, Version 2.0 (the "License");
  ;you may not use this file except in compliance with the License.

--- a/src/_webrsp.m
+++ b/src/_webrsp.m
@@ -1,4 +1,4 @@
-%webrsp ;SLC/KCM -- Handle HTTP Response;2019-11-14  11:02 AM
+%webrsp ;SLC/KCM -- Handle HTTP Response;Jun 20, 2022@14:47
  ;
  ; -- prepare and send RESPONSE
  ;
@@ -371,10 +371,10 @@ GZIP ; EP to write gzipped content
  QUIT
  ;
 RSPERROR ; set response to be an error response
- Q:$G(NOGBL)
- D encode^%webjson("^TMP(""HTTPERR"",$J,1)","^TMP(""HTTPERR"",$J,""JSON"")")
- S HTTPRSP="^TMP(""HTTPERR"",$J,""JSON"")"
- K HTTPRSP("pageable")
+ ; Count is a temporary variable to track multiple errors... don't send it back
+ ; pageable is VPR code, not used, but kept for now.
+ K HTTPERR("count"),HTTPRSP("pageable")
+ D encode^%webjson($NAME(HTTPERR),$NAME(HTTPRSP))
  Q
 RSPLINE() ; writes out a response line based on HTTPERR
  ; VEN/SMH: TODO: There ought to be a simpler way to do this!!!
@@ -411,6 +411,7 @@ AUTHEN(HTTPAUTH) ; Authenticate User against VISTA from HTTP Authorization Heade
  ; Portions of this code are public domain, but it was extensively modified
  ; Copyright 2013-2020 Sam Habiel
  ; Copyright 2018-2019 Christopher Edwards
+ ; Copyright 2022 YottaDB LLC
  ;
  ;Licensed under the Apache License, Version 2.0 (the "License");
  ;you may not use this file except in compliance with the License.

--- a/src/_weburl.m
+++ b/src/_weburl.m
@@ -1,17 +1,21 @@
-%weburl ;YottaDB/CJE -- URL Matching routine;2019-11-14  11:14 AM
+%weburl ;YottaDB/CJE -- URL Matching routine;Jun 20, 2022@14:48
  ;
  ; This routine is used to map URLs to entry points under
  ; the URLMAP entry point.
  ;
 URLMAP ;
  ;;GET ping ping^%webapi
+ ;;GET /r/{routine?.1""%25"".32AN} R^%webapi
  ;;GET /test/xml xml^%webapi
  ;;GET /test/empty empty^%webapi
- ;;GET /test/customerror customerr^%webapi
+ ;;GET test/customerror customerr^%webapi
+ ;;GET test/error ERR^%webapi
+ ;;POST test/post POSTTEST^%webapi
  ;;zzzzz
  ;
  ; Copyright 2019 Christopher Edwards
  ; Copyright 2019 Sam Habiel
+ ; Copyright 2022 YottaDB LLC
  ;
  ;Licensed under the Apache License, Version 2.0 (the "License");
  ;you may not use this file except in compliance with the License.

--- a/src/webinit.m
+++ b/src/webinit.m
@@ -1,5 +1,5 @@
 webinit ; OSE/SMH - Initialize Web Server;2019-11-14  2:36 PM
- ;;1.1.2;MASH WEB SERVER/WEB SERVICES
+ ;;1.1.3;MASH WEB SERVER/WEB SERVICES
  ;
  ; Map %web on Cache
  DO CACHEMAP("%web")
@@ -8,7 +8,7 @@ webinit ; OSE/SMH - Initialize Web Server;2019-11-14  2:36 PM
  DO CACHETLS
  ;
  ; Install the package
- D INSTALLRO("https://github.com/shabiel/M-Web-Server/releases/download/1.1.2/mws.rsa")
+ D INSTALLRO("https://github.com/shabiel/M-Web-Server/releases/download/1.1.3/mws.rsa")
  ;
  ; If fileman is installed, do an init for the %web(17.001 file
 post ; [Public] Run this entry point if you don't want to download the code.


### PR DESCRIPTION
The main change is moving setting the error data from
`^TMP("HTTPERR",$J)` to `HTTPERR`. This way globals are not required
anymore, and we can report errors in NOGBL mode.

`src/webinit.m`:

- v1.1.2 -> 1.1.3

`src/_webapi.m`:

- Update POSTTEST entry point so it's usable in the no global mode
- Add fonts to the MIME list

`src/_webhome.m`:

- Fix error check
- If no request handlers are installed, say so explicitly

`src/_web{req,rsp,utils}.m`

- Move error data from `^TMP("HTTPERR",$J)` to `HTTPERR`.
- Remove unused VPR server errors dealing with patient data

`src/_weburl.m`

- Add various handlers for the unit tests

`src/_webtest.m`

- Improve Error checks
- Add `tpost` test that explicitly tests HTTP post
- Remove test that check for `^TMP("HTTPERR") as that doesn't exist
  anymore after the refactoring done in this PR.
- Add `NOGBLERR` test that tests for errors in NOGBL mode
- Add `NOGBLPOST` test that tests HTTP POST in NOGBL mode

Cosmetic changes:

- `doc/INSTALL.md`
- `doc/debugging.md`
- `doc/important-utilities.md`
- `src/_webjson.m`
- `src/_webjsonDecode.m`
- `src/_webjsonEncode.m`