### PR TITLE
WIP: [#49] Handle multi-char percentage sign escapes in URL decoding on GTM

### DIFF
--- a/src/_webutils.m
+++ b/src/_webutils.m
@@ -37,7 +37,7 @@ URLDEC(X,PATH) ; Decode a URL-encoded string
  F I=1:1:$L(X,"%") D
  . I I=1 S OUT=$P(X,"%") Q
  . S FRAG=$P(X,"%",I),ASC=$E(FRAG,1,2),FRAG=$E(FRAG,3,$L(FRAG))
- . I $L(ASC) S OUT=OUT_$C($$HEX2DEC(ASC))
+ . I $L(ASC) S OUT=OUT_$$FUNC^%HEX2UTF(ASC)
  . S OUT=OUT_FRAG
  Q OUT
  ;


### PR DESCRIPTION
This solution probably only work on GTM in UTF-8 mode. Maybe it can serve as a starting point for a portable fix.